### PR TITLE
raytracingcamp5 Docker仕立て Jupyterを添えて

### DIFF
--- a/raytracingcamp5.ipynb
+++ b/raytracingcamp5.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# raytracingcamp5 Docker仕立て Jupyterを添えて\n",
+    "\n",
+    "今給黎先生のレイトレ合宿5用のサンプルプロジェクトを、Dockerコンテナを使って動かしてみる。WindowsでもMacでもLinuxでも、Dockerをインストールすれば、以下に説明する手順で、主にwebブラウザ経由で使うことができる。\n",
+    "\n",
+    "# 使い方\n",
+    "\n",
+    "## Jupyter起動\n",
+    "\n",
+    "dockerコマンドが使えるとこで、\n",
+    "\n",
+    "```\n",
+    "# docker run -d -v /var/run/docker.sock:/var/run/docker.sock -p 8888:8888 -e GRANT_SUDO=yes --user root --name jupyter jupyter/minimal-notebook start-notebook.sh --NotebookApp.token=''\n",
+    "```\n",
+    "\n",
+    "を実行するとJupyterが8888番ポートでアクセスできる状態で起動する。\n",
+    "\n",
+    "## Jupyter接続\n",
+    "\n",
+    "webブラウザから、起動したJupyterにアクセスする。例えば、操作しているPC上に起動した場合は、localhostの8888番ポートにアクセスすればよいので、\n",
+    "\n",
+    "```\n",
+    "http://localhost:8888/\n",
+    "```\n",
+    "\n",
+    "でアクセスできる。\n",
+    "\n",
+    "## raytracingcamp5.ipynbのUpload\n",
+    "\n",
+    "webブラウザで、JupyterのHome画面が出たら、右上にある「Upload」ボタンから、この文書「raytracingcamp5.ipynb」をアップロードする。アップロードが完了して、Home画面の一覧に「raytracingcamp5.ipynb」が表示されたら、クリックして「raytracingcamp5.ipynb」での操作に移る。\n",
+    "\n",
+    "## サンプルプロジェクトのクローン\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "# rm -rf raytracingcamp5\n",
+    "git clone --depth 1 https://github.com/mnagaku/raytracingcamp5.git\n",
+    "cd raytracingcamp5\n",
+    "ls -lsa"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## サンプルプロジェクトのビルド\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "cd raytracingcamp5/src\n",
+    "mkdir bin\n",
+    "make clean\n",
+    "make depend\n",
+    "make\n",
+    "ls -lsaR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## サンプルプロジェクトの実行\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "cd raytracingcamp5/src/bin\n",
+    "date\n",
+    "./a.out\n",
+    "date\n",
+    "ls -la"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 実行結果\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/01.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/02.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/03.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/04.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/05.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/06.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/07.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/08.png\n",
+    "\n",
+    "http://localhost:8888/view/raytracingcamp5/src/bin/09.png\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/raytracingcamp5.ipynb
+++ b/raytracingcamp5.ipynb
@@ -99,23 +99,23 @@
    "source": [
     "## 実行結果\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/01.png\n",
+    "[01.png](/view/raytracingcamp5/src/bin/01.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/02.png\n",
+    "[02.png](/view/raytracingcamp5/src/bin/02.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/03.png\n",
+    "[03.png](/view/raytracingcamp5/src/bin/03.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/04.png\n",
+    "[04.png](/view/raytracingcamp5/src/bin/04.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/05.png\n",
+    "[05.png](/view/raytracingcamp5/src/bin/05.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/06.png\n",
+    "[06.png](/view/raytracingcamp5/src/bin/06.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/07.png\n",
+    "[07.png](/view/raytracingcamp5/src/bin/07.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/08.png\n",
+    "[08.png](/view/raytracingcamp5/src/bin/08.png)\n",
     "\n",
-    "http://localhost:8888/view/raytracingcamp5/src/bin/09.png\n"
+    "[09.png](/view/raytracingcamp5/src/bin/09.png)\n"
    ]
   }
  ],


### PR DESCRIPTION
レイトレ合宿5用のサンプルプロジェクトを、Dockerコンテナを使って動かしてみる手順を、Jupyterのnotebookにまとめました。WindowsでもMacでもLinuxでも、Dockerをインストールすれば、主にwebブラウザ経由でビルド・実行ができます。
既存のファイルには手を入れないで、一種の文書が追加されるだけで、影響はないと思うので、よかったらmargeをお願いします。